### PR TITLE
Netlify oss

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+(This CoC is based on [Rust’s Code of Conduct].)
+
+## Conduct
+
+- We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
+- Please avoid using overtly sexual aliases or other nicknames that might detract from a friendly, safe and welcoming environment for all.
+- Please be kind and courteous. There’s no need to be mean or rude.
+- Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
+- Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
+- We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We interpret the term “harassment” as including the definition in the [Citizen Code of Conduct]; if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.
+- Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact the moderation team. Whether you’re a regular contributor or a newcomer, we care about making this community a safe place for you and we’ve got your back.
+- Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
+
+## Moderation
+
+These are the policies for upholding our community’s standards of conduct. If you feel that a thread or issue needs moderation, please contact the Rust moderation team.
+
+- Remarks that violate the Rust standards of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)
+- Remarks that moderators find inappropriate, whether listed in the code of conduct or not, are also not allowed.
+- Moderators will first respond to such remarks with a warning.
+- If the warning is unheeded, the user will be “kicked,” i.e., kicked out of the communication channel to cool off.
+- If the user comes back and continues to make trouble, they will be banned, i.e., indefinitely excluded.
+- Moderators may choose at their discretion to un-ban the user if it was a first offense and they offer the offended party a genuine apology.
+- If a moderator bans someone and you think it was unjustified, please take it up with that moderator, or with a different moderator, in private. Complaints about bans in-channel are not allowed.
+- Moderators are held to a higher standard than other community members. If a moderator creates an inappropriate situation, they should expect less leeway than others.
+
+We strive to go the extra step to look out for each other. Don’t just aim to be technically unimpeachable, try to be your best self. In particular, avoid flirting with offensive or sensitive issues, particularly if they’re off-topic; this all too often leads to unnecessary fights, hurt feelings, and damaged trust; worse, it can drive people away from the community entirely.
+
+And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could’ve communicated better — remember that it’s your responsibility to make volunteers feel welcome. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.
+
+The enforcement policies listed above apply to all official Squoosh communication channels.
+
+## Moderators
+
+- @jaffathecake
+- @surma
+
+[rust’s code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[citizen code of conduct]: https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -15,9 +15,9 @@
 
 ## Moderation
 
-These are the policies for upholding our community’s standards of conduct. If you feel that a thread or issue needs moderation, please contact the Rust moderation team.
+These are the policies for upholding our community’s standards of conduct. If you feel that a thread or issue needs moderation, please contact the Squoosh moderation team.
 
-- Remarks that violate the Rust standards of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)
+- Remarks that violate the Squoosh standards of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)
 - Remarks that moderators find inappropriate, whether listed in the code of conduct or not, are also not allowed.
 - Moderators will first respond to such remarks with a warning.
 - If the warning is unheeded, the user will be “kicked,” i.e., kicked out of the communication channel to cool off.

--- a/src/shared/prerendered-app/Intro/index.tsx
+++ b/src/shared/prerendered-app/Intro/index.tsx
@@ -441,13 +441,13 @@ export default class Intro extends Component<Props, State> {
                 </a>
                 <a
                   class={style.footerLink}
-                  href="https://github.com/GoogleChromeLabs/squoosh/blob/dev/README.md#privacy"
+                  href="https://github.com/squoosh-app/squoosh/blob/dev/README.md#privacy"
                 >
                   Privacy
                 </a>
                 <a
                   class={style.footerLinkWithLogo}
-                  href="https://github.com/GoogleChromeLabs/squoosh"
+                  href="https://github.com/squoosh-app/squoosh"
                 >
                   <img src={githubLogo} alt="" width="10" height="10" />
                   Source on Github

--- a/src/shared/prerendered-app/Intro/index.tsx
+++ b/src/shared/prerendered-app/Intro/index.tsx
@@ -436,6 +436,9 @@ export default class Intro extends Component<Props, State> {
             </svg>
             <div class={style.footerPadding}>
               <footer class={style.footerItems}>
+                <a class={style.footerNetlifyLink} href="https://netlify.com">
+                  This site is powered by Netlify.
+                </a>
                 <a
                   class={style.footerLink}
                   href="https://github.com/GoogleChromeLabs/squoosh/blob/dev/README.md#privacy"

--- a/src/shared/prerendered-app/Intro/style.css
+++ b/src/shared/prerendered-app/Intro/style.css
@@ -249,9 +249,9 @@
   justify-items: center;
   gap: 2rem;
 
-  @media (min-width: 480px) {
-    justify-content: end;
-    grid-auto-flow: column;
+  @media (min-width: 580px) {
+    width: 100%;
+    grid-template-columns: 1fr repeat(2, max-content);
     align-items: center;
     gap: 4rem;
   }
@@ -260,6 +260,13 @@
 .footer-link {
   text-decoration: none;
   color: inherit;
+}
+
+.footer-netlify-link {
+  composes: footer-link;
+  @media (min-width: 580px) {
+    justify-self: start;
+  }
 }
 
 .footer-link-with-logo {


### PR DESCRIPTION
This PR adds a Code of Conduct as well as a backlink to Netlify so we can apply for [Netlify’s OSS Plan Policy](https://www.netlify.com/legal/open-source-policy/).

![Screenshot 2023-12-18 at 13 07 55](https://github.com/squoosh-app/squoosh/assets/234957/3b80f11c-87fb-4628-a251-325174559ef7)
